### PR TITLE
Serialization and Allocation tunning

### DIFF
--- a/src/main/java/com/example/starter/DataOut.java
+++ b/src/main/java/com/example/starter/DataOut.java
@@ -1,0 +1,31 @@
+package com.example.starter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import io.vertx.core.buffer.impl.BufferImpl;
+
+public final class DataOut extends OutputStream {
+
+	final BufferImpl buf;
+
+	public DataOut(BufferImpl buf) {
+		this.buf = buf;
+	}
+
+	public DataOut reset() {
+		buf.byteBuf().clear();
+		return this;
+	}
+
+	@Override
+	public void write(byte[] b, int off, int len) throws IOException {
+		buf.appendBytes(b, off, len);
+	}
+
+	@Override
+	public void write(int b) throws IOException {
+		buf.appendByte((byte) (b & 0xFF));
+	}
+
+}

--- a/src/main/java/com/example/starter/User.java
+++ b/src/main/java/com/example/starter/User.java
@@ -1,23 +1,45 @@
 package com.example.starter;
 
-public class User {
-    public int id;
-    public String firstName;
-    public String lastName;
-    public int age;
-    public String Framework;
+import java.io.IOException;
 
-    public User(
-            int id,
-            String firstName,
-            String lastName,
-            int age,
-            String framework
-    ) {
-        this.id = id;
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.age = age;
-        Framework = framework;
-    }
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializable;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+
+public class User implements JsonSerializable {
+	public int id;
+	public String firstName;
+	public String lastName;
+	public int age;
+	public String Framework;
+
+	public User(
+			int id,
+			String firstName,
+			String lastName,
+			int age,
+			String framework) {
+		this.id = id;
+		this.firstName = firstName;
+		this.lastName = lastName;
+		this.age = age;
+		Framework = framework;
+	}
+
+	@Override
+	public void serialize(JsonGenerator gen, SerializerProvider serializers) throws IOException {
+		gen.writeStartObject();
+		gen.writeNumberField("id", id);
+		gen.writeStringField("firstName", firstName);
+		gen.writeStringField("lastName", lastName);
+		gen.writeNumberField("age", age);
+		gen.writeStringField("Framework", Framework);
+		gen.writeEndObject();
+	}
+
+	@Override
+	public void serializeWithType(JsonGenerator gen, SerializerProvider serializers, TypeSerializer typeSer) throws IOException {
+		serialize(gen, serializers);
+	}
 }


### PR DESCRIPTION
The way the original code is laid out is not favorable to Java.

There are lots of copying and unnecessary allocations going on and by default, it will use a (cached) BeanSerializer instance to convert users to JSON, which is OK, but it can't compete with serde.

The handler method always allocates an ArrayList to mirror Rust's code, but it should not. Rust most likely optimizes the allocation in the function's scope since the size is well known at compile time. To give Java a fighting chance streaming and short-lived objects (or pooled Lists) should be used instead.

I think a 1000 request warmup may be too low for the benchmark since by default Tier4 (C2 compilation) needs 15000 invocations.

Here is the script I've used.

```bash
#!/bin/bash

warm=50000
max=1000000
port=8888
url=http://localhost:${port}/
curl $url
oha -n $warm $url
reset
oha -n $max -c 100 --latency-correction --disable-keepalive $url
echo $done
```

Consider also running benchmarks with

```
-XX:+AlwaysPreTouch -XX:+UseCompressedOops
```

With this PR's changes (for details see [attached file](https://github.com/Vagelis-Prokopiou/yt-web-api-java-vertx/files/9229308/bench.txt)), here are some numbers

| Version  |  GC  |  Xms  |  Xmx  | Requests/sec |
| ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
|  Baseline |  Parallel | 128m | 128m | 5079.6801 |
|  Baseline |  Parallel | - | - | 5860.9208 |
|  Baseline |  G1 | 128m | 128m | 6034.1087 |
|  Baseline |  G1 | - | - | 5999.3922 |
|  Baseline |  Z | - | - | 4906.0679 |
|  PR |  Parallel | 128m | 128m | 8964.3218 |
|  PR |  Parallel | - | - | 9272.5775 |
|  PR |  G1 | 128m | 128m | 8543.7730 |
|  PR |  G1 | - | - | 9112.0940 |
|  PR |  Z | - | - | 9675.3352 |


I also noticed that **oha** claims a fair amount of CPU. Of course this has negative impact on both Java and Rust benchmarks, but usually the penalty is a bit larger for managed runtimes since they have their own internal scheduling competing for resources.